### PR TITLE
Add editEnded signals, triggered only at the end of the widget edit (mouse release or text submit)

### DIFF
--- a/include/doubleslider.hpp
+++ b/include/doubleslider.hpp
@@ -43,11 +43,16 @@ namespace ValueSliders {
 
         void emitValueUpdated(double val) override;
 
+        void emitEditEnded() override;
+
         [[nodiscard]] double getValueByPosition(int x) override;
 
     Q_SIGNALS:
 
         void valueUpdated(double value);
+
+        void editEnded();
+
     private:
 
         void updateBounds();

--- a/include/intslider.hpp
+++ b/include/intslider.hpp
@@ -42,6 +42,8 @@ namespace ValueSliders {
 
         void emitValueUpdated(int val) override;
 
+        void emitEditEnded() override;      
+      
         [[nodiscard]] int getValueByPosition(int x) override;
 
         void mousePressEvent(QMouseEvent *event) override;
@@ -49,6 +51,8 @@ namespace ValueSliders {
     Q_SIGNALS:
 
         void valueUpdated(int value);
+
+        void editEnded();
 
     private:
         double moveValue_;

--- a/include/valueslider.hpp
+++ b/include/valueslider.hpp
@@ -79,6 +79,8 @@ namespace ValueSliders {
 
         virtual void emitValueUpdated(T val) = 0;
 
+        virtual void emitEditEnded() = 0;      
+      
         virtual T getValueByPosition(int x) = 0;
 
     protected:

--- a/src/doubleslider.cpp
+++ b/src/doubleslider.cpp
@@ -40,6 +40,10 @@ void ValueSliders::DoubleSlider::emitValueUpdated(double val) {
     emit valueUpdated(val);
 }
 
+void ValueSliders::DoubleSlider::emitEditEnded() {
+    emit editEnded();
+}
+
 double ValueSliders::DoubleSlider::getValueByPosition(int x) {
     double ratio = static_cast<double>(x) / width();
     double val = ratio * (maximum() - minimum());

--- a/src/intslider.cpp
+++ b/src/intslider.cpp
@@ -45,6 +45,10 @@ void ValueSliders::IntSlider::emitValueUpdated(int val) {
     emit valueUpdated(val);
 }
 
+void ValueSliders::IntSlider::emitEditEnded() {
+    emit editEnded();
+}
+
 int ValueSliders::IntSlider::getValueByPosition(int x) {
     double ratio = static_cast<double>(x) / width();
     double val = ratio * (maximum() - minimum());

--- a/src/valueslider.cpp
+++ b/src/valueslider.cpp
@@ -181,6 +181,7 @@ void ValueSliders::ValueSlider<T>::mouseReleaseEvent(QMouseEvent *event) {
         if (event->button() == Qt::LeftButton) {
             QCursor::setPos(startPos_);
             updateValueByPosition(event->pos().x() - oldPos_);
+            emitEditEnded();
         }
         QApplication::restoreOverrideCursor();
     } else {


### PR DESCRIPTION
NB - is actually the same as PR #12 but resubmitted because of rebase issues