### PR TITLE
[CI] Update action versions in pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Checkout
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Install packages
       - name: Install dependencies
@@ -33,7 +33,7 @@ jobs:
 
       # Upload cppcheck
       - name: Upload cppcheck report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cppcheck-report
           path: cppcheck-report.txt
@@ -71,7 +71,7 @@ jobs:
     steps:
       # Checkout
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Install packages
       - name: Install dependencies
@@ -97,7 +97,7 @@ jobs:
     steps:
       # Checkout
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Install packages
       - name: Install dependencies


### PR DESCRIPTION
This MR fixes the usage of the deprecated/removed `actions/upload-artifact: v3`. It also updates some of the other actions to `v4`

closes #22 