### PR TITLE
[CI] Ensure clang-format fails if formatting errors are detected

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,102 @@
+---
+# General configuration that applies to all files
+BasedOnStyle: LLVM
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: false
+BreakStringLiterals: true
+ColumnLimit: 120
+ContinuationIndentWidth: 4
+IndentWidth: 4
+SpaceBeforeAssignmentOperators: true
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInConditionalStatement: false
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: 1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+TabWidth: 4
+UseCRLF: false
+UseTab: Never
+---
+# C++ specific configuration
+Language: Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Left
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: Consecutive
+AlignConsecutiveDeclarations: None
+AlignConsecutiveMacros: Consecutive
+AlignEscapedNewlines: Left
+AlignOperands: Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BitFieldColonSpacing: Both
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+FixNamespaceComments: true
+IncludeBlocks: Preserve
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: false
+IndentPPDirectives: None
+InsertBraces: true
+InsertTrailingCommas: None
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PackConstructorInitializers: CurrentLine
+PointerAlignment: Left
+QualifierAlignment: Left
+ReferenceAlignment: Left
+ReflowComments: false
+SeparateDefinitionBlocks: Always
+SortIncludes: Never
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       # Install packages
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential cmake cppcheck clang-format libgtest-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake cppcheck git-clang-format libgtest-dev
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
@@ -41,7 +41,7 @@ jobs:
       # Lint: clang-format
       - name: Lint C++ files (clang-format)
         run: |
-          find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format --Werror
+          git-clang-format --diff --quiet || exit 1
 
       # Lint: cmakelint
       - name: Install pip and cmakelint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout
@@ -18,7 +18,9 @@ jobs:
 
       # Install packages
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential cmake cppcheck clang-format libgtest-dev
+        run: |
+          sudo apt-get update && sudo apt-get install -y build-essential cmake cppcheck clang-format libgtest-dev python3-pip
+          pip install cmakelint
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
@@ -26,45 +28,55 @@ jobs:
           cache: 'true'
           cache-key-prefix: 'install-qt6-action'
 
-      # Analysis: cppcheck
-      - name: Static analysis (cppcheck)
+      # cppcheck
+      - name: cppcheck
         run: |
           cppcheck --enable=all --inconclusive --std=c++17 --force . 2> cppcheck-report.txt || true
 
       # Upload cppcheck
-      - name: Upload cppcheck report
+      - name: cppcheck report
         uses: actions/upload-artifact@v4
         with:
           name: cppcheck-report
           path: cppcheck-report.txt
 
-      # Lint: clang-format
-      - name: Lint C++ files (clang-format)
+      # clang-format
+      - name: clang-format
         run: |
-          git-clang-format --diff --quiet || exit 1
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git-clang-format origin/${{ github.event.pull_request.base.ref }} --diff --quiet || exit 1
 
-      # Lint: cmakelint
-      - name: Install pip and cmakelint
-        run: |
-          sudo apt-get install -y python3-pip
-          pip install cmakelint
-
-      - name: Lint CMake files
+      # cmakelint
+      - name: cmakelint
         run: |
           find . -name 'CMakeLists.txt' -o -name '*.cmake' | xargs cmakelint --linelength=120
 
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Install packages
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake libgtest-dev
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.5.*'
+          cache: 'true'
+          cache-key-prefix: 'install-qt6-action'
+
       # Build
-      - name: Create build directory
-        run: mkdir build
-
-      - name: Configure with CMake
-        run: cmake -S . -B build -DBUILD_TESTS=ON
-
-      - name: Build with CMake
-        run: cmake --build build
+      - name: Build
+        run: |
+          mkdir build
+          cmake -S . -B build -DBUILD_TESTS=ON
+          cmake --build build
 
       # Test
-      - name: Run tests
+      - name: Run unit tests
         run: cd build && QT_QPA_PLATFORM="offscreen" ctest --output-on-failure --verbose
   build-without-tests:
     runs-on: ubuntu-latest
@@ -84,14 +96,11 @@ jobs:
           cache-key-prefix: 'install-qt6-action'
 
       # Build
-      - name: Create build directory
-        run: mkdir build
-
-      - name: Configure with CMake
-        run: cmake -S . -B build -DBUILD_TESTS=OFF
-
-      - name: Build with CMake
-        run: cmake --build build
+      - name: build
+        run: |
+          mkdir build
+          cmake -S . -B build -DBUILD_TESTS=OFF
+          cmake --build build
   build-qt5:
     runs-on: ubuntu-latest
     steps:
@@ -110,15 +119,12 @@ jobs:
           cache-key-prefix: 'install-qt5-action'
 
       # Build
-      - name: Create build directory
-        run: mkdir build
-
-      - name: Configure with CMake
-        run: cmake -S . -B build -DBUILD_TESTS=ON
-
-      - name: Build with CMake
-        run: cmake --build build
+      - name: Build
+        run: |
+          mkdir build
+          cmake -S . -B build -DBUILD_TESTS=ON
+          cmake --build build
 
       # Test
-      - name: Run tests
+      - name: Run unit tests
         run: cd build && QT_QPA_PLATFORM="offscreen" ctest --output-on-failure --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       # Install packages
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential cmake cppcheck git-clang-format libgtest-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake cppcheck clang-format libgtest-dev
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       # Lint: clang-format
       - name: Lint C++ files (clang-format)
         run: |
-          find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i
+          find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format --Werror
 
       # Lint: cmakelint
       - name: Install pip and cmakelint

--- a/include/doubleslider.hpp
+++ b/include/doubleslider.hpp
@@ -10,8 +10,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -23,38 +23,37 @@
  */
 #pragma once
 
-#include <QProgressBar>
 #include "valueslider.hpp"
+#include <QProgressBar>
 
 namespace ValueSliders {
 
-    class DoubleSlider : public ValueSlider<double> {
+class DoubleSlider : public ValueSlider<double> {
     Q_OBJECT
-    public:
-        DoubleSlider(QString name, double value);
+  public:
+    DoubleSlider(QString name, double value);
 
-        DoubleSlider(QString name, double value, double min, double max, BoundMode boundMode = BoundMode::UPPER_LOWER);
+    DoubleSlider(QString name, double value, double min, double max, BoundMode boundMode = BoundMode::UPPER_LOWER);
 
-        [[nodiscard]] int transform(double val) const override;
+    [[nodiscard]] int transform(double val) const override;
 
-        double convertString(const QString &string, bool &ok) override;
+    double convertString(const QString& string, bool& ok) override;
 
-        [[nodiscard]] QString createString(double val) const override;
+    [[nodiscard]] QString createString(double val) const override;
 
-        void emitValueUpdated(double val) override;
+    void emitValueUpdated(double val) override;
 
-        void emitEditEnded() override;
+    void emitEditEnded() override;
 
-        [[nodiscard]] double getValueByPosition(int x) override;
+    [[nodiscard]] double getValueByPosition(int x) override;
 
-    Q_SIGNALS:
+  Q_SIGNALS:
 
-        void valueUpdated(double value);
+    void valueUpdated(double value);
 
-        void editEnded();
+    void editEnded();
 
-    private:
-
-        void updateBounds();
-    };
-} // ValueSliders
+  private:
+    void updateBounds();
+};
+}  // namespace ValueSliders

--- a/include/intslider.hpp
+++ b/include/intslider.hpp
@@ -1,7 +1,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2023 Niels Bugel
+ * Copyright (c) 2023-2025 Niels Bugel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,8 +10,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -27,36 +27,36 @@
 
 namespace ValueSliders {
 
-    class IntSlider : public ValueSlider<int> {
+class IntSlider : public ValueSlider<int> {
     Q_OBJECT
-    public:
-        IntSlider(QString name, int value);
+  public:
+    IntSlider(QString name, int value);
 
-        IntSlider(QString name, int value, int min, int max, BoundMode boundMode = BoundMode::UPPER_LOWER);
+    IntSlider(QString name, int value, int min, int max, BoundMode boundMode = BoundMode::UPPER_LOWER);
 
-        [[nodiscard]] int transform(int val) const override;
+    [[nodiscard]] int transform(int val) const override;
 
-        int convertString(const QString &string, bool &ok) override;
+    int convertString(const QString& string, bool& ok) override;
 
-        [[nodiscard]] QString createString(int val) const override;
+    [[nodiscard]] QString createString(int val) const override;
 
-        void emitValueUpdated(int val) override;
+    void emitValueUpdated(int val) override;
 
-        void emitEditEnded() override;      
-      
-        [[nodiscard]] int getValueByPosition(int x) override;
+    void emitEditEnded() override;
 
-        void mousePressEvent(QMouseEvent *event) override;
+    [[nodiscard]] int getValueByPosition(int x) override;
 
-    Q_SIGNALS:
+    void mousePressEvent(QMouseEvent* event) override;
 
-        void valueUpdated(int value);
+  Q_SIGNALS:
 
-        void editEnded();
+    void valueUpdated(int value);
 
-    private:
-        double moveValue_;
+    void editEnded();
 
-        void updateBounds();
-    };
-} // ValueSliders
+  private:
+    double moveValue_;
+
+    void updateBounds();
+};
+}  // namespace ValueSliders

--- a/include/valueslider.hpp
+++ b/include/valueslider.hpp
@@ -1,7 +1,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2023 Niels Bugel
+ * Copyright (c) 2023-2025 Niels Bugel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,8 +10,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -27,75 +27,69 @@
 
 namespace ValueSliders {
 
-    enum class BoundMode {
-        UNCHECKED,
-        UPPER_ONLY,
-        LOWER_ONLY,
-        UPPER_LOWER
-    };
+enum class BoundMode { UNCHECKED, UPPER_ONLY, LOWER_ONLY, UPPER_LOWER };
 
-    template<class T>
-    class ValueSlider : public QProgressBar {
-    public:
-        ValueSlider(QString name, T value);
+template<class T>
+class ValueSlider : public QProgressBar {
+  public:
+    ValueSlider(QString name, T value);
 
-        ValueSlider(QString name, T value, T min, T max, BoundMode boundMode);
+    ValueSlider(QString name, T value, T min, T max, BoundMode boundMode);
 
-        ~ValueSlider() override;
+    ~ValueSlider() override;
 
-        void setVal(T value);
+    void setVal(T value);
 
-        [[nodiscard]] T getVal() const;
+    [[nodiscard]] T getVal() const;
 
-        [[nodiscard]] T boundVal(T value) const;
+    [[nodiscard]] T boundVal(T value) const;
 
-    protected:
+  protected:
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
 
-        void mouseDoubleClickEvent(QMouseEvent *event) override;
+    void mousePressEvent(QMouseEvent* event) override;
 
-        void mousePressEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
 
-        void mouseMoveEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
 
-        void mouseReleaseEvent(QMouseEvent *event) override;
+    void keyPressEvent(QKeyEvent* event) override;
 
-        void keyPressEvent(QKeyEvent *event) override;
+    [[nodiscard]] QString text() const override;
 
-        [[nodiscard]] QString text() const override;
+    void paintEvent(QPaintEvent* event) override;
 
-        void paintEvent(QPaintEvent *event) override;
+    void focusOutEvent(QFocusEvent* event) override;
 
-        void focusOutEvent(QFocusEvent *event) override;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    void enterEvent(QEnterEvent* event) override;
+#else
+    void enterEvent(QEvent* event) override;
+#endif
 
-        #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        void enterEvent(QEnterEvent *event) override;
-        #else
-        void enterEvent(QEvent *event) override;
-        #endif
+    void leaveEvent(QEvent* event) override;
 
-        void leaveEvent(QEvent *event) override;
+    virtual int transform(T val) const = 0;
 
-        virtual int transform(T val) const = 0;
+    virtual T convertString(const QString& string, bool& ok) = 0;
 
-        virtual T convertString(const QString &string, bool &ok) = 0;
+    virtual QString createString(T val) const = 0;
 
-        virtual QString createString(T val) const = 0;
+    virtual void emitValueUpdated(T val) = 0;
 
-        virtual void emitValueUpdated(T val) = 0;
+    virtual void emitEditEnded() = 0;
 
-        virtual void emitEditEnded() = 0;      
-      
-        virtual T getValueByPosition(int x) = 0;
+    virtual T getValueByPosition(int x) = 0;
 
-    protected:
-        T value_;
-        T min_;
-        T max_;
-        BoundMode boundMode_ = BoundMode::UNCHECKED;
+  protected:
+    T value_;
+    T min_;
+    T max_;
+    BoundMode boundMode_ = BoundMode::UNCHECKED;
 
-    private:
-        const int padding_ = 12;
-        const int blinkerInterval_ = 500;
+  private:
+    const int padding_ = 12;
+    const int blinkerInterval_ = 500;
 
         // This determines how "fine" is the tuning. If the constant
         // equals 64 for example, the slider tick is 64th times
@@ -112,20 +106,20 @@ namespace ValueSliders {
         QString typeInput_ = "";
         QString name_ = "value";
 
-        void updateValueByPosition(int x);
+    void updateValueByPosition(int x);
 
-        void init();
+    void init();
 
-        void toggleBlinkerVisibility();
+    void toggleBlinkerVisibility();
 
-        void startTyping();
+    void startTyping();
 
-        void stopTyping();
+    void stopTyping();
 
-        void submitTypedInput();
+    void submitTypedInput();
 
-        [[nodiscard]] int getXPosByVal() const;
+    [[nodiscard]] int getXPosByVal() const;
 
-        bool slidingHover_ = false;
-    };
-} // ValueSliders
+    bool slidingHover_ = false;
+};
+}  // namespace ValueSliders

--- a/include/valueslider.hpp
+++ b/include/valueslider.hpp
@@ -91,20 +91,20 @@ class ValueSlider : public QProgressBar {
     const int padding_ = 12;
     const int blinkerInterval_ = 500;
 
-        // This determines how "fine" is the tuning. If the constant
-        // equals 64 for example, the slider tick is 64th times
-        // smaller.
-        const int fineTuningThreshold_ = 64;
+    // This determines how "fine" is the tuning. If the constant
+    // equals 64 for example, the slider tick is 64th times
+    // smaller.
+    const int fineTuningThreshold_ = 64;
 
-        bool blinkerVisible_ = false;
-        bool typing_ = false;
-        bool mouseMoved_ = false;
-        int oldPos_;
-        QPoint startPos_;
-        int pendingDiff_ = 0;
-        std::shared_ptr<QTimer> blinkerTimer_ = nullptr;
-        QString typeInput_ = "";
-        QString name_ = "value";
+    bool blinkerVisible_ = false;
+    bool typing_ = false;
+    bool mouseMoved_ = false;
+    int oldPos_;
+    QPoint startPos_;
+    int pendingDiff_ = 0;
+    std::shared_ptr<QTimer> blinkerTimer_ = nullptr;
+    QString typeInput_ = "";
+    QString name_ = "value";
 
     void updateValueByPosition(int x);
 

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -1,12 +1,12 @@
 #include <QApplication>
+#include <QLabel>
 #include <QMainWindow>
 #include <QVBoxLayout>
-#include <QLabel>
 
 #include "doubleslider.hpp"
 #include "intslider.hpp"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     QApplication app(argc, argv);
     QFont font("Lato");
     font.setPixelSize(14);
@@ -18,8 +18,8 @@ int main(int argc, char *argv[]) {
     wrapper.setLayout(&layout);
 
     layout.addWidget(new QLabel("This is a small demo program:"));
-    layout.addWidget(new ValueSliders::DoubleSlider("Double"));
-    layout.addWidget(new ValueSliders::IntSlider("Integer"));
+    layout.addWidget(new ValueSliders::DoubleSlider("Double", 10.0));
+    layout.addWidget(new ValueSliders::IntSlider("Integer", 10));
 
     layout.addWidget(new ValueSliders::DoubleSlider("Bounded Double", 50, 0, 100));
     layout.addWidget(new ValueSliders::IntSlider("Custom Name", 0, -50, 50));

--- a/src/doubleslider.cpp
+++ b/src/doubleslider.cpp
@@ -1,23 +1,25 @@
 #include "doubleslider.hpp"
 
-#include <utility>
 #include <cmath>
+#include <utility>
 
 ValueSliders::DoubleSlider::DoubleSlider(QString name, double value) : ValueSlider(std::move(name), value) {
     updateBounds();
 }
 
-ValueSliders::DoubleSlider::DoubleSlider(QString name, double value, double min, double max,
-                                         ValueSliders::BoundMode boundMode) : ValueSlider(std::move(name), value, min,
-                                                                                          max,
-                                                                                          boundMode) {
+ValueSliders::DoubleSlider::DoubleSlider(QString name,
+                                         double value,
+                                         double min,
+                                         double max,
+                                         ValueSliders::BoundMode boundMode)
+    : ValueSlider(std::move(name), value, min, max, boundMode) {
     updateBounds();
 }
 
 void ValueSliders::DoubleSlider::updateBounds() {
     setMinimum(int(std::round(min_ * 100.0)));
     setMaximum(int(std::round(max_ * 100.0)));
-    if(boundMode_ == BoundMode::UPPER_LOWER) {
+    if (boundMode_ == BoundMode::UPPER_LOWER) {
         setValue(int(std::round(value_ * 100.0)));
     } else {
         setValue(minimum());
@@ -28,7 +30,7 @@ int ValueSliders::DoubleSlider::transform(double val) const {
     return int(std::round(val * 100.0));
 }
 
-double ValueSliders::DoubleSlider::convertString(const QString &string, bool &ok) {
+double ValueSliders::DoubleSlider::convertString(const QString& string, bool& ok) {
     return string.toDouble(&ok);
 }
 

--- a/src/intslider.cpp
+++ b/src/intslider.cpp
@@ -7,30 +7,26 @@ ValueSliders::IntSlider::IntSlider(QString name, int value) : ValueSlider(std::m
     updateBounds();
 }
 
-ValueSliders::IntSlider::IntSlider(QString name, int value, int min, int max,
-                                   ValueSliders::BoundMode boundMode) : ValueSlider(std::move(name), value, min,
-                                                                                    max,
-                                                                                    boundMode) {
+ValueSliders::IntSlider::IntSlider(QString name, int value, int min, int max, ValueSliders::BoundMode boundMode)
+    : ValueSlider(std::move(name), value, min, max, boundMode) {
     updateBounds();
 }
 
 void ValueSliders::IntSlider::updateBounds() {
-
     setMinimum(min_);
     setMaximum(max_);
-    if(boundMode_ == BoundMode::UPPER_LOWER) {
+    if (boundMode_ == BoundMode::UPPER_LOWER) {
         setValue(value_);
     } else {
         setValue(minimum());
     }
 }
 
-
 int ValueSliders::IntSlider::transform(int val) const {
     return val;
 }
 
-int ValueSliders::IntSlider::convertString(const QString &string, bool &ok) {
+int ValueSliders::IntSlider::convertString(const QString& string, bool& ok) {
     return string.toInt(&ok);
 }
 
@@ -66,7 +62,7 @@ int ValueSliders::IntSlider::getValueByPosition(int x) {
     return int(std::round(moveValue_));
 }
 
-void ValueSliders::IntSlider::mousePressEvent(QMouseEvent *event) {
+void ValueSliders::IntSlider::mousePressEvent(QMouseEvent* event) {
     ValueSlider::mousePressEvent(event);
     moveValue_ = value_;
 }

--- a/src/valueslider.cpp
+++ b/src/valueslider.cpp
@@ -155,22 +155,22 @@ void ValueSliders::ValueSlider<T>::mouseMoveEvent(QMouseEvent* event) {
         return;
     }
     if (event->buttons() & Qt::LeftButton) {
-      int diff = event->pos().x() - oldPos_;
+        int diff = event->pos().x() - oldPos_;
 
-      if (event->modifiers() & Qt::ControlModifier) {
-        pendingDiff_ +=diff;
+        if (event->modifiers() & Qt::ControlModifier) {
+            pendingDiff_ += diff;
 
-        if (std::abs(pendingDiff_) < fineTuningThreshold_) {
-          return;
+            if (std::abs(pendingDiff_) < fineTuningThreshold_) {
+                return;
+            }
+            diff = pendingDiff_ > 0 ? 1 : -1;
         }
-        diff = pendingDiff_ > 0 ? 1 : -1;
-      }
-      pendingDiff_ = 0;
+        pendingDiff_ = 0;
 
-      QCursor::setPos(startPos_);
-      updateValueByPosition(diff);
-      mouseMoved_ = true;
-      return;
+        QCursor::setPos(startPos_);
+        updateValueByPosition(diff);
+        mouseMoved_ = true;
+        return;
     }
 }
 

--- a/src/valueslider.cpp
+++ b/src/valueslider.cpp
@@ -55,7 +55,7 @@ void ValueSliders::ValueSlider<T>::init() {
 
 template<class T>
 void ValueSliders::ValueSlider<T>::toggleBlinkerVisibility() {
-    blinkerVisible_ =!blinkerVisible_;
+    blinkerVisible_ = !blinkerVisible_;
     update();
 }
 

--- a/src/valueslider.cpp
+++ b/src/valueslider.cpp
@@ -1,16 +1,15 @@
 #include "valueslider.hpp"
 
+#include <QApplication>
 #include <QMouseEvent>
 #include <QPainter>
-#include <QTimer>
 #include <QStyleOptionProgressBar>
+#include <QTimer>
 #include <utility>
-#include <QApplication>
 
 template<class T>
-ValueSliders::ValueSlider<T>::ValueSlider(QString name, T value)
-        : name_(std::move(name)),
-          value_(value) {
+ValueSliders::ValueSlider<T>::ValueSlider(QString name, T value) : name_(std::move(name)),
+                                                                   value_(value) {
     if (value > 0) {
         min_ = 0;
         max_ = value_ * 2;
@@ -26,20 +25,19 @@ ValueSliders::ValueSlider<T>::ValueSlider(QString name, T value)
 
 template<class T>
 ValueSliders::ValueSlider<T>::ValueSlider(QString name, T value, T min, T max, BoundMode boundMode)
-        : boundMode_(boundMode),
-          name_(std::move(name)),
-          value_(value),
-          min_(min),
-          max_(max) {
-
+    : boundMode_(boundMode),
+      name_(std::move(name)),
+      value_(value),
+      min_(min),
+      max_(max) {
     if (min > max) {
-        throw std::invalid_argument(
-                QString("ValueSlider min val cannot be greater than max val.\nMin: %1\nMax: %2\n").arg(min,
-                                                                                                       max).toStdString());
+        throw std::invalid_argument(QString("ValueSlider min val cannot be greater "
+                                            "than max val.\nMin: %1\nMax: %2\n")
+                                        .arg(min, max)
+                                        .toStdString());
     }
     init();
 }
-
 
 template<class T>
 ValueSliders::ValueSlider<T>::~ValueSlider() {
@@ -89,7 +87,7 @@ void ValueSliders::ValueSlider<T>::stopTyping() {
 }
 
 template<class T>
-void ValueSliders::ValueSlider<T>::paintEvent(QPaintEvent *event) {
+void ValueSliders::ValueSlider<T>::paintEvent(QPaintEvent* event) {
     QProgressBar::paintEvent(event);
 
     QPainter painter(this);
@@ -135,11 +133,10 @@ void ValueSliders::ValueSlider<T>::paintEvent(QPaintEvent *event) {
         QRect valueRect = rect.adjusted(QFontMetrics(font()).horizontalAdvance(nameText), 0, -padding_, 0);
         painter.drawText(valueRect, Qt::AlignRight | Qt::AlignVCenter, valueText);
     }
-
 }
 
 template<class T>
-void ValueSliders::ValueSlider<T>::mousePressEvent(QMouseEvent *event) {
+void ValueSliders::ValueSlider<T>::mousePressEvent(QMouseEvent* event) {
     setFocus();
     if (typing_) {
         return;
@@ -153,7 +150,7 @@ void ValueSliders::ValueSlider<T>::mousePressEvent(QMouseEvent *event) {
 }
 
 template<class T>
-void ValueSliders::ValueSlider<T>::mouseMoveEvent(QMouseEvent *event) {
+void ValueSliders::ValueSlider<T>::mouseMoveEvent(QMouseEvent* event) {
     if (typing_) {
         return;
     }
@@ -186,7 +183,7 @@ int ValueSliders::ValueSlider<T>::getXPosByVal() const {
 }
 
 template<class T>
-void ValueSliders::ValueSlider<T>::mouseReleaseEvent(QMouseEvent *event) {
+void ValueSliders::ValueSlider<T>::mouseReleaseEvent(QMouseEvent* event) {
     if (mouseMoved_) {
         if (event->button() == Qt::LeftButton) {
             emitEditEnded();
@@ -210,14 +207,14 @@ void ValueSliders::ValueSlider<T>::updateValueByPosition(int x) {
 }
 
 template<class T>
-void ValueSliders::ValueSlider<T>::mouseDoubleClickEvent(QMouseEvent *event) {
+void ValueSliders::ValueSlider<T>::mouseDoubleClickEvent(QMouseEvent* event) {
     if (event->button() == Qt::LeftButton && !typing_) {
         startTyping();
     }
 }
 
 template<class T>
-void ValueSliders::ValueSlider<T>::keyPressEvent(QKeyEvent *event) {
+void ValueSliders::ValueSlider<T>::keyPressEvent(QKeyEvent* event) {
     if (typing_) {
         event->accept();
         if (event->key() == Qt::Key_Escape) {
@@ -259,7 +256,7 @@ void ValueSliders::ValueSlider<T>::submitTypedInput() {
 }
 
 template<class T>
-void ValueSliders::ValueSlider<T>::focusOutEvent(QFocusEvent *event) {
+void ValueSliders::ValueSlider<T>::focusOutEvent(QFocusEvent* event) {
     if (typing_) {
         submitTypedInput();
     }
@@ -303,9 +300,9 @@ T ValueSliders::ValueSlider<T>::getVal() const {
 
 template<class T>
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-void ValueSliders::ValueSlider<T>::enterEvent(QEnterEvent *event) {
+void ValueSliders::ValueSlider<T>::enterEvent(QEnterEvent* event) {
 #else
-void ValueSliders::ValueSlider<T>::enterEvent(QEvent *event) {
+void ValueSliders::ValueSlider<T>::enterEvent(QEvent* event) {
 #endif
     if (!typing_ && !slidingHover_) {
         QApplication::setOverrideCursor(Qt::SizeHorCursor);
@@ -314,15 +311,13 @@ void ValueSliders::ValueSlider<T>::enterEvent(QEvent *event) {
 }
 
 template<class T>
-void ValueSliders::ValueSlider<T>::leaveEvent(QEvent *event) {
+void ValueSliders::ValueSlider<T>::leaveEvent(QEvent* event) {
     if (!typing_) {
         QApplication::restoreOverrideCursor();
         slidingHover_ = false;
     }
 }
 
-template
-class ValueSliders::ValueSlider<int>;
+template class ValueSliders::ValueSlider<int>;
 
-template
-class ValueSliders::ValueSlider<double>;
+template class ValueSliders::ValueSlider<double>;

--- a/src/valueslider.cpp
+++ b/src/valueslider.cpp
@@ -55,7 +55,7 @@ void ValueSliders::ValueSlider<T>::init() {
 
 template<class T>
 void ValueSliders::ValueSlider<T>::toggleBlinkerVisibility() {
-    blinkerVisible_ = !blinkerVisible_;
+    blinkerVisible_ =!blinkerVisible_;
     update();
 }
 

--- a/test/apptestenvironment.cpp
+++ b/test/apptestenvironment.cpp
@@ -1,13 +1,13 @@
-#include <gtest/gtest.h>
 #include <QApplication>
+#include <gtest/gtest.h>
 
 class QtTestEnvironment : public ::testing::Environment {
-public:
-    QApplication *app = nullptr;
+  public:
+    QApplication* app = nullptr;
 
     virtual void SetUp() {
         int argc = 0;
-        char **argv = nullptr;
+        char** argv = nullptr;
         app = new QApplication(argc, argv);
     }
 
@@ -18,4 +18,4 @@ public:
 };
 
 // Register the environment
-::testing::Environment *const env = ::testing::AddGlobalTestEnvironment(new QtTestEnvironment());
+::testing::Environment* const env = ::testing::AddGlobalTestEnvironment(new QtTestEnvironment());

--- a/test/doubleslider_test.cpp
+++ b/test/doubleslider_test.cpp
@@ -1,6 +1,6 @@
+#include "doubleslider.hpp"
 #include <QApplication>
 #include <gtest/gtest.h>
-#include "doubleslider.hpp"
 
 TEST(DoubleSliderTest, ConstructorDefaultPositive) {
     double val = 10.0;
@@ -128,7 +128,8 @@ TEST(DoubleSliderTest, ConvertStringToDouble) {
     EXPECT_DOUBLE_EQ(slider.convertString("-5.5", ok), -5.5);
     EXPECT_TRUE(ok);
 
-    EXPECT_DOUBLE_EQ(slider.convertString("abc", ok), 0.0); // Assuming it returns 0 for invalid input
+    EXPECT_DOUBLE_EQ(slider.convertString("abc", ok),
+                     0.0);  // Assuming it returns 0 for invalid input
     EXPECT_FALSE(ok);
 }
 

--- a/test/intslider_test.cpp
+++ b/test/intslider_test.cpp
@@ -1,6 +1,6 @@
+#include "intslider.hpp"
 #include <QApplication>
 #include <gtest/gtest.h>
-#include "intslider.hpp"
 
 TEST(IntSliderTest, ConstructorDefaultPositive) {
     int val = 10;


### PR DESCRIPTION
The clang-format step of the CI does not fail correctly if formatting errors are present. This should be fixed.